### PR TITLE
move samsara-core/is-timestamp-reliable to separate module

### DIFF
--- a/core/src/samsara_core/core.clj
+++ b/core/src/samsara_core/core.clj
@@ -1,6 +1,7 @@
 (ns samsara-core.core
   (:require [moebius.core :refer :all])
   (:require [moebius.kv :as kv])
+  (:require [samsara-core.time :refer [is-timestamp-reliable]])
   (:require [digest :refer [sha-256]]))
 
 
@@ -11,28 +12,6 @@
       (inject-as :ts (java.util.Date. timestamp))
       (inject-as :receivedAtTs (and receivedAt (java.util.Date. receivedAt)))
       (inject-as :publishedAtTs (and publishedAt (java.util.Date. publishedAt)))))
-
-
-
-(defenrich is-timestamp-reliable
-  #_"It verifies if the client timestamp seems reliable,
-   and if it is it will inject and attribute `timeReliable`
-   true/false."
-  [{:keys [timestamp receivedAt publishedAt] :as event}]
-  (when (and timestamp receivedAt publishedAt)
-        (assoc event :timeReliable
-               (cond
-                ;; is the timestamp coming from
-                ;; the future
-                (> timestamp publishedAt)  false
-                (> publishedAt receivedAt) false
-                ;; is received - published within
-                ;; a reasonable time (10s) otherwise we consider ti bogus
-                (not (>= 10000 (Math/abs (- receivedAt publishedAt)) 0)) false
-                ;; is the event generated within a
-                ;; reasonable time? 10d otherwise is bogus
-                (not (>= (* 10 24 60 60 1000) (- publishedAt timestamp) 0)) false
-                :else true))))
 
 
 

--- a/core/src/samsara_core/time.clj
+++ b/core/src/samsara_core/time.clj
@@ -1,0 +1,24 @@
+(ns samsara-core.time
+  (:require [moebius.core :refer :all]))
+
+
+
+(defenrich is-timestamp-reliable
+  #_"It verifies if the client timestamp seems reliable,
+   and if it is it will inject and attribute `timeReliable`
+   true/false."
+  [{:keys [timestamp receivedAt publishedAt] :as event}]
+  (when (and timestamp receivedAt publishedAt)
+        (assoc event :timeReliable
+               (cond
+                ;; is the timestamp coming from
+                ;; the future
+                (> timestamp publishedAt)  false
+                (> publishedAt receivedAt) false
+                ;; is received - published within
+                ;; a reasonable time (10s) otherwise we consider ti bogus
+                (not (>= 10000 (Math/abs (- receivedAt publishedAt)) 0)) false
+                ;; is the event generated within a
+                ;; reasonable time? 10d otherwise is bogus
+                (not (>= (* 10 24 60 60 1000) (- publishedAt timestamp) 0)) false
+                :else true))))


### PR DESCRIPTION
addresses #29

unable to properly test due to (probably stupid deps issue)
```
λ lein deps
Could not find artifact samsara:moebius:jar:0.5.7.0-SNAPSHOT in clojars (https://clojars.org/repo/)
Could not find artifact samsara:samsara-utils:jar:0.5.7.0-SNAPSHOT in clojars (https://clojars.org/repo/)
This could be due to a typo in :dependencies or network issues.
If you are behind a proxy, try setting the 'http_proxy' environment variable.```

but besides the `:refer :all` i can't think of anything particularly wrong with this