### PR TITLE
Change ordering of sed & gsed Darwin on start-script

### DIFF
--- a/bin/start-samsara.sh
+++ b/bin/start-samsara.sh
@@ -14,7 +14,7 @@ BASE=$(cd $(dirname $0)/../docker-images && pwd)
 SAM=$BASE/..
 VER=${1:-latest}
 BVER=${2:-master}
-[ `uname` == "Darwin" ] && export SED=gsed || export SED=sed
+[ `uname` == "Darwin" ] && export SED=sed || export SED=gsed
 
 
 echo ''


### PR DESCRIPTION
Problem with the script is that the precedence rules will result in ```gsed``` always being selected.
On OS X systems, that is quite problematic.

I understand the contribution process, this is a very small change, hence I thought I would place it here.

**Problems solved**: lowers friction for getting started running the system.